### PR TITLE
Miscellaneous bug fixes for stable/1.2

### DIFF
--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -517,9 +517,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 	    storeSol = MibSRelaxationSol;
 	}
 	else{
-		for (i = 0; i < lN; i++){
-			optLowerSolutionOrd_[i] = lowerSol[i];
-	    }
+	    memcpy(optLowerSolutionOrd_, lowerSol, sizeof(double) * lN);
 	    if(isUpperIntegral_){
 	        storeSol = MibSHeurSol;
 	    }

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -522,7 +522,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 	       (((branchPar == MibSBranchingStrategyLinking) &&
 		 (isIntegral_) && (isLinkVarsFixed_)) ||
 		((computeBestUBWhenXVarsInt == PARAM_ON) && (isUpperIntegral_)) ||
-		((computeBestUBWhenLVarsInt == PARAM_ON)) ||
+		((computeBestUBWhenLVarsInt == PARAM_ON)  && (isLinkVarsIntegral_)) ||
 		((computeBestUBWhenLVarsFixed == PARAM_ON) && (isLinkVarsFixed_)))){
 		if(UBSolver_){
 		    UBSolver_ = setUpUBModel(model_->getSolver(), objVal, false);
@@ -649,7 +649,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 		    shouldPrune_ = true;
 		}	
 	    }
-	    else if ((tagInSeenLinkingPool_ != MibSLinkingPoolTagUBIsSolved) ||
+	    else if ((tagInSeenLinkingPool_ == MibSLinkingPoolTagLowerIsFeasible) ||
 		     ((!useLinkingSolutionPool) && (isUBSolved_))){
 		for (i = 0; i < lN; i++){
 		    index = lowerColInd[i];

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -283,7 +283,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
     double remainingTime(0.0), startTimeVF(0.0), startTimeUB(0.0);
     MibSSolType storeSol(MibSNoSol);
     int lN(model_->lowerDim_); // lower-level dimension
-    int uN(model_->upperDim_); // lower-level dimension
+    int uN(model_->upperDim_); // upper-level dimension
     int i(0), index(0), length(0), pos(0);
     int sizeFixedInd(model_->sizeFixedInd_);
     double etol(model_->etol_), objVal(0.0), lowerObj(0.0);
@@ -442,17 +442,16 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 
 	    const double * values = lSolver->getColSolution();
 	    
-		// YX: round solution before saving or passing
-		for (i = 0; i < lN; i++){			 
-		    index = lowerColInd[i];
-		    if ((lSolver->isInteger(index)) &&
-			(((values[i] - floor(values[i])) < etol) ||
-			 ((ceil(values[i]) - values[i]) < etol))){
-			    lowerSol[i] = (double) floor(values[i] + 0.5);
-		    }else{
-			    lowerSol[i] = (double) values[i];
-		    }
-	    }
+        // YX: round lSolver solution; sol (Relaxation soln) is not rounded?
+        for (i = 0; i < lN; i++){			 
+            if ((lSolver->isInteger(i)) &&
+                (((values[i] - floor(values[i])) < etol) ||
+                ((ceil(values[i]) - values[i]) < etol))){
+                lowerSol[i] = (double) floor(values[i] + 0.5);
+            }else{
+                lowerSol[i] = (double) values[i];
+            }
+        }
 
 	    if(useLinkingSolutionPool && isLinkVarsIntegral_){
 		std::copy(lowerSol, lowerSol + lN, shouldStoreValuesLowerSol.begin());

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -517,8 +517,9 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 	    storeSol = MibSRelaxationSol;
 	}
 	else{
-		for (i = 0; i < lN; i++){			 
-		    pos = binarySearch(0, lN - 1, i, lowerColInd);
+		for (i = 0; i < lN; i++){
+			index = lowerColInd[i];
+			pos = binarySearch(0, lN - 1, index, lowerColInd);	
 			optLowerSolutionOrd_[pos] = lowerSol[i];
 	    }
 	    if(isUpperIntegral_){

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -518,9 +518,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 	}
 	else{
 		for (i = 0; i < lN; i++){
-			index = lowerColInd[i];
-			pos = binarySearch(0, lN - 1, index, lowerColInd);	
-			optLowerSolutionOrd_[pos] = lowerSol[i];
+			optLowerSolutionOrd_[i] = lowerSol[i];
 	    }
 	    if(isUpperIntegral_){
 	        storeSol = MibSHeurSol;

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -601,14 +601,17 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 		UBSolver->branchAndBound();
 		model_->timerUB_ += model_->broker_->subTreeTimer().getTime() - startTimeUB;
 		model_->counterUB_ ++;
-		isUBSolved_ = true;
+		
 		if((feasCheckSolver == "SYMPHONY") && (sym_is_time_limit_reached
 						       (dynamic_cast<OsiSymSolverInterface *>
 							(UBSolver)->getSymphonyEnvironment()))){
 		    shouldPrune_ = true;
 		    goto TERM_CHECKBILEVELFEAS;
 		}
-		else if (UBSolver->isProvenOptimal()){
+
+		isUBSolved_ = true;
+
+		if (UBSolver->isProvenOptimal()){
 		    isProvenOptimal_ = true;
 		    const double * valuesUB = UBSolver->getColSolution();
 		    std::copy(valuesUB, valuesUB + uN + lN, shouldStoreValuesUBSol.begin());
@@ -637,7 +640,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 		    storeSol = MibSHeurSol;
 		}else{
 		    isProvenOptimal_ = false;
-			storeSol = MibSNoSol;
+		    storeSol = MibSNoSol;
 		}
 		//step 22
 		//Adding x_L to set E

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -486,7 +486,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
     }
 
     //step 13
-    if(((!useLinkingSolutionPool || !isContainedInLinkingPool_) && (isProvenOptimal_)) ||
+    if(((!useLinkingSolutionPool || !isLinkVarsIntegral_) && (isProvenOptimal_)) ||
        ((tagInSeenLinkingPool_ == MibSLinkingPoolTagLowerIsFeasible) ||
 	(tagInSeenLinkingPool_ == MibSLinkingPoolTagUBIsSolved))){
 

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -637,6 +637,7 @@ MibSBilevel::checkBilevelFeasiblity(bool isRoot)
 		    storeSol = MibSHeurSol;
 		}else{
 		    isProvenOptimal_ = false;
+			storeSol = MibSNoSol;
 		}
 		//step 22
 		//Adding x_L to set E

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -5257,9 +5257,10 @@ MibSCutGenerator::binaryCuts(BcpsConstraintPool &conPool)
    int useGeneralNoGoodCut 
       = localModel_->MibSPar_->entry(MibSParams::useGeneralNoGoodCut);
    
-   bool useIncObjCut 
+   int useIncObjCut 
       = localModel_->MibSPar_->entry(MibSParams::useIncObjCut);
-
+   
+   // YX: CAUTION! confirm the conditions before use; vars are int not bool  
    if(useGeneralNoGoodCut && !useIncObjCut){
       return generalNoGoodCut(conPool) ? true : false;
    }
@@ -5916,7 +5917,7 @@ MibSCutGenerator::generateConstraints(BcpsConstraintPool &conPool)
   int useNoGoodCut = 
      localModel_->MibSPar_->entry(MibSParams::useNoGoodCut);
   
-  bool useIncObjCut
+  int useIncObjCut
      = localModel_->MibSPar_->entry(MibSParams::useIncObjCut);
   
   int useFractionalCuts =

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -3442,6 +3442,8 @@ MibSModel::instanceStructure()
                  << "linking variables are binary.";
        std::cout << std::endl;
        MibSPar()->setEntry(MibSParams::useIncObjCut, PARAM_OFF);
+    }else if (paramValue == PARAM_NOTSET){
+       MibSPar()->setEntry(MibSParams::useIncObjCut, PARAM_OFF);
     }
     
     //Param: "MibS_useNoGoodCut"


### PR DESCRIPTION
Some problems found in checkBilevelFeasibility()

- L525: when entering the UB solving block, the corresponding parameter `isLinkVarsIntegral_` to `computeBestUBWhenLVarsInt` was missing; this reflects the mibs paper, where the parameter was also not included (for some unknown reason?) But I think it is still necessary...
- L652: this condition will check if `(x, \hat{y})`  is bilevel feasible and mark it as a heuristic solution; the tag here is changed to explicitly `LowerIsFeasible` because the old one includes `NotSet` case, and if linking solution pool is not used, the condition will always be satisfied. The case `LowerIsInfeasible` is already filtered at `!shouldPrune_`.
- L540 & L604 (not included in this (1st) commit as I am still thinking about a good way to rearrange):  these are two `TERM`s in the UB block when the time limit is reached. However, here, labeling the solution as `NoSol`  and jumping to termination directly ignores the heuristic solution `(x, \hat{y})` check at L652.

2nd commit summary (see details in the review comments):

- L652: moved the block `(x, \hat{y})` related to right after SL-MILP is solved, and marked `HeurSol` before entering the UB block; added sorting but not yet tested;
- L540 & L604: removed the statement because of the above change.
- running tests on the RAND_BILEVEL test set