### PR TITLE
Review: adding lower-level objective gap and pessimistic case related functions

### DIFF
--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -1065,7 +1065,7 @@ MibSBilevel::setUpUBModel(OsiSolverInterface * oSolver, double objValLL,
     int * fixedInd = model_->fixedInd_;
 
     int i(0), j(0), index1(0);
-    double value(0.0);
+    double value(0.0), objUb(0.0);
 
     int uCols(model_->getUpperDim());
     int uRows(model_->getOrigUpperRowNum());
@@ -1074,14 +1074,10 @@ MibSBilevel::setUpUBModel(OsiSolverInterface * oSolver, double objValLL,
     int rowNum(model_->getNumOrigCons() + 1);
     int colNum(model_->getNumOrigVars());
     int * uColIndices(model_->getUpperColInd());
-    double gap = (targetGap < model_->etol_) ? 0.0 : targetGap; // YX: added SL gap
-    double objUb(0.0);
+    double gap = (targetGap < model_->getTolerance()) ? 0.0 : targetGap; // YX: added SL gap
+
     // YX: d2^y <= phi(A^x) + \delta * abs(phi(A^x))
-    if(objValLL > 0){
-        objUb = objValLL + objValLL* gap/100;
-    }else{
-        objUb = objValLL - objValLL* gap/100;
-    }
+    objUb = objValLL + fabs(objValLL) * gap/100;
 
     if(newOsi){
 	double objSense(model_->getLowerObjSense());
@@ -1247,14 +1243,10 @@ MibSBilevel::setUpPesModel(OsiSolverInterface * oSolver, double objValLL,
    int colNum(model_->getNumOrigVars());
    int *uColIndices(model_->getUpperColInd());
    int *fixedInd(model_->getFixedInd());
-   double gap = (targetGap < model_->etol_) ? 0.0 : targetGap; // YX: added SL gap
+   double gap = (targetGap < model_->getTolerance()) ? 0.0 : targetGap; // YX: added SL gap
 
    // YX: d2^y <= phi(A^x) + \delta * abs(phi(A^x))
-   if(objValLL > 0){ // YX: change to abs value later
-      objUb = objValLL + objValLL* gap/100;
-   }else{
-      objUb = objValLL - objValLL* gap/100;
-   }
+   objUb = objValLL + fabs(objValLL) * gap/100;
 
    if (!lpSol){
       lpSol = oSolver->getColSolution();

--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -85,14 +85,18 @@ MibSBilevel::createBilevel(CoinPackedVector* sol,
   int numElements(sol->getNumElements()); // number of nonzero elements
   int * fixedInd = model_->fixedInd_; 
  
-  if(!upperSolutionOrd_)
+  if(!upperSolutionOrd_){
       upperSolutionOrd_ = new double[uN];
-  if(!lowerSolutionOrd_)
+  }
+  if(!lowerSolutionOrd_){
       lowerSolutionOrd_ = new double[lN];
-  if(!optUpperSolutionOrd_)
+  }
+  if(!optUpperSolutionOrd_){
       optUpperSolutionOrd_ = new double[uN];
-  if(!optLowerSolutionOrd_)
+  }
+  if(!optLowerSolutionOrd_){
       optLowerSolutionOrd_ = new double[lN];
+  }
   
   CoinZeroN(upperSolutionOrd_, uN);
   CoinZeroN(lowerSolutionOrd_, lN);
@@ -239,7 +243,7 @@ MibSBilevel::createBilevel(CoinPackedVector* sol,
 	   (solveSecondLevelWhenXVarsInt && isUpperIntegral_) ||
 	   (solveSecondLevelWhenLVarsInt && isLinkVarsIntegral_) ||
 	   (solveSecondLevelWhenLVarsFixed && isLinkVarsFixed_ )))){
-	  storeSol = checkBilevelFeasiblity(mibs->isRoot_);
+	  storeSol = checkBilevelFeasibility(mibs->isRoot_);
       }
   }
   
@@ -257,7 +261,7 @@ MibSBilevel::createBilevel(CoinPackedVector* sol,
 
 //#############################################################################
 MibSSolType
-MibSBilevel::checkBilevelFeasiblity(bool isRoot)
+MibSBilevel::checkBilevelFeasibility(bool isRoot)
 {
     bool warmStartLL(model_->MibSPar_->entry
 		     (MibSParams::warmStartLL));

--- a/src/MibSBilevel.hpp
+++ b/src/MibSBilevel.hpp
@@ -111,15 +111,14 @@ public:
 
 private:
    
-    int findIndex(int index, int size, int * indices);
+    OsiSolverInterface * setUpPesUBModel(double *lowerSol, bool newOsi); // YX: pessimistic case
     OsiSolverInterface * setUpUBModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL);
-    OsiSolverInterface * setUpPesUBModel(OsiSolverInterface * solver, double objValLL,
-					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpPesModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpModel(OsiSolverInterface * solver,
 				    bool newOsi, const double *sol = NULL);
+    int findIndex(int index, int size, int * indices); // YX: not used?
     double getLowerObj(const double * sol, double objSense);
     double getRiskFuncVal(double *lowerSol, bool pesType); // YX: pessimistic case
     double getUpperObj(double *lowerSol, bool pesType); // YX: pessimistic case

--- a/src/MibSBilevel.hpp
+++ b/src/MibSBilevel.hpp
@@ -104,7 +104,7 @@ public:
    
     MibSSolType createBilevel(CoinPackedVector *sol,
 		       MibSModel *mibs=0);
-    MibSSolType checkBilevelFeasiblity(bool isRoot);
+    MibSSolType checkBilevelFeasibility(bool isRoot);
     void gutsOfDestructor();
 
 private:

--- a/src/MibSBilevel.hpp
+++ b/src/MibSBilevel.hpp
@@ -114,14 +114,14 @@ private:
     OsiSolverInterface * setUpPesUBModel(double *lowerSol, bool newOsi); // YX: pessimistic case
     OsiSolverInterface * setUpUBModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL);
-    OsiSolverInterface * setUpPesModel(OsiSolverInterface * solver, double objValLL,
-					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
+    OsiSolverInterface * setUpPesModel(double objValLL, bool newOsi, 
+                    const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpModel(OsiSolverInterface * solver,
 				    bool newOsi, const double *sol = NULL);
     int findIndex(int index, int size, int * indices); // YX: not used?
     double getLowerObj(const double * sol, double objSense);
-    double getRiskFuncVal(double *lowerSol, bool pesType); // YX: pessimistic case
-    double getUpperObj(double *lowerSol, bool pesType); // YX: pessimistic case
+    double getRiskFuncVal(double *lowerSol); // YX: pessimistic case
+    double getUpperObj(double *lowerSol); // YX: pessimistic case
     int binarySearch(int index,int start, int stop, int * indexArray);
     CoinWarmStart * getWarmStart() {return ws_;}
     void setWarmStart(CoinWarmStart * ws) {ws_ = ws;}

--- a/src/MibSBilevel.hpp
+++ b/src/MibSBilevel.hpp
@@ -73,6 +73,7 @@ private:
     MibSModel *model_;
     MibSHeuristic *heuristic_;
     OsiSolverInterface * lSolver_;
+    OsiSolverInterface * pSolver_; // YX: pessimistic case
     OsiSolverInterface * UBSolver_;
     CoinWarmStart * ws_;
    
@@ -94,6 +95,7 @@ public:
 	model_ = 0;
 	heuristic_= 0;
 	lSolver_ = 0;
+    pSolver_ = 0; // YX: pessimistic case
 	UBSolver_ = 0;
 	ws_ = 0;
     }
@@ -112,9 +114,12 @@ private:
     int findIndex(int index, int size, int * indices);
     OsiSolverInterface * setUpUBModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL);
+    OsiSolverInterface * setUpPesModel(OsiSolverInterface * solver, double objValLL,
+					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpModel(OsiSolverInterface * solver,
 				    bool newOsi, const double *sol = NULL);
     double getLowerObj(const double * sol, double objSense);
+    double getRiskFuncVal(OsiSolverInterface * solver, double * lowerSol, bool pesType); // YX: pessimistic case
     int binarySearch(int index,int start, int stop, int * indexArray);
     CoinWarmStart * getWarmStart() {return ws_;}
     void setWarmStart(CoinWarmStart * ws) {ws_ = ws;}

--- a/src/MibSBilevel.hpp
+++ b/src/MibSBilevel.hpp
@@ -114,12 +114,15 @@ private:
     int findIndex(int index, int size, int * indices);
     OsiSolverInterface * setUpUBModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL);
+    OsiSolverInterface * setUpPesUBModel(OsiSolverInterface * solver, double objValLL,
+					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpPesModel(OsiSolverInterface * solver, double objValLL,
 					  bool newOsi, const double *sol = NULL); // YX: pessimistic case
     OsiSolverInterface * setUpModel(OsiSolverInterface * solver,
 				    bool newOsi, const double *sol = NULL);
     double getLowerObj(const double * sol, double objSense);
-    double getRiskFuncVal(OsiSolverInterface * solver, double * lowerSol, bool pesType); // YX: pessimistic case
+    double getRiskFuncVal(double *lowerSol, bool pesType); // YX: pessimistic case
+    double getUpperObj(double *lowerSol, bool pesType); // YX: pessimistic case
     int binarySearch(int index,int start, int stop, int * indexArray);
     CoinWarmStart * getWarmStart() {return ws_;}
     void setWarmStart(CoinWarmStart * ws) {ws_ = ws;}

--- a/src/MibSConstants.hpp
+++ b/src/MibSConstants.hpp
@@ -58,6 +58,8 @@ enum MibSLinkingPoolTag{
     MibSLinkingPoolTagIsNotSet = -4,
     MibSLinkingPoolTagLowerIsInfeasible,
     MibSLinkingPoolTagLowerIsFeasible,
+    MibSLinkingPoolTagPesIsInfeasible, // YX: pessimistic case
+    MibSLinkingPoolTagPesIsFeasible, // YX: pessimistic case
     MibSLinkingPoolTagUBIsSolved
 };
 

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -1110,9 +1110,10 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
 	    //the optimal solution of relaxation which satisfies integrality requirements
 	    //throw CoinError("The MIP which gives the best lower-level sol, cannot be infeasible!",
            //		    "findLowerLevelSol", "MibSCutGenerator");
-      if(targetGap > etol){
-        std::cout << "Type2IC aux MILP with optimality gap is infeasible."<<std::endl;     
-      }
+      // if(targetGap > etol){
+      //   std::cout << "Type2IC aux MILP with optimality gap is infeasible."<<std::endl;     
+      // } // YX: debug only; remove later
+    }
     }
 
     delete [] multA2XOpt;
@@ -1318,7 +1319,7 @@ MibSCutGenerator::solveModelIC(double *uselessIneqs, double *ray, double *rhs,
 //#############################################################################
 bool
 MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lowerLevelSol,
-						double* lpSol, bool &isTimeLimReached)
+						double *optLowerSol, double* lpSol, bool &isTimeLimReached)
 {
     std::string feasCheckSolver(localModel_->MibSPar_->entry
 				(MibSParams::feasCheckSolver));
@@ -1345,8 +1346,8 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
     int lCols(localModel_->getLowerDim());
     int lRows(localModel_->getLowerRowNum());
     int numContCols(lRows + 2 * lCols);
+    int newNumCols(lCols + numContCols);
     int newNumRows = (targetGap > etol)? (2 * lRows + 2 * lCols + 2) : (2 * lRows + 2 * lCols + 1); // YX: nonzero gap add a constraint
-    int newNumRows(2 * lRows + 2 * lCols + 1);
     double lObjSense(localModel_->getLowerObjSense());
     double *lObjCoeff(localModel_->getLowerObjCoeffs());
     int *lColInd(localModel_->getLowerColInd());
@@ -1524,8 +1525,8 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
       rhs = 0;
       for(i = 0; i < lCols; i++){
         colIndex = lColInd[i];
-        rhs += lObjSense * lObjCoeffs[i] * (lpSol[colIndex] - lowerSolution[i]);
-        templObj += lObjSense * lObjCoeff[i] * lowerSolution[i]; // YX: track d^2y^*
+        rhs += lObjSense * lObjCoeff[i] * (lpSol[colIndex] - optLowerSol[i]);
+        templObj += lObjSense * lObjCoeff[i] * optLowerSol[i]; // YX: track d^2y^*
       }
       if(templObj > 0){
         rhs += -templObj * gap/100;
@@ -1620,9 +1621,9 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
 	//std::cout << "current time = " << timeLimit - localModel_->broker_->subTreeTimer().getTime() << std::endl;
 	//throw CoinError("The MIP which is solved for watermelon IC, cannot be infeasible!",
 	//		"findLowerLevelSolWatermelonIC", "MibSCutGenerator");
-      if(targetGap > etol){
-        std::cout << "Watermelon aux MILP with optimality gap is infeasible."<<std::endl;     
-      }    
+      // if(targetGap > etol){
+      //   std::cout << "Watermelon aux MILP with optimality gap is infeasible."<<std::endl;     
+      // }  // YX: debug only; remove later  
     }
     delete [] lCoeffsTimesLpSol;
     return foundSolution;

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -891,16 +891,20 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
     int *integerVars = new int[newNumCols];
     CoinZeroN(integerVars, newNumCols);
 
+  //   if(!localModel_->getA2Matrix()){
+	// getA2Matrix = true;
+  //   }
+
+  //   if(!localModel_->getG2Matrix()){
+	// getG2Matrix = true;
+  //   }
+
+  //   if((getA2Matrix) || (getG2Matrix)){
+	// getLowerMatrices(false, getA2Matrix, getG2Matrix);
+  //   }
+
     if(!localModel_->getA2Matrix()){
-	getA2Matrix = true;
-    }
-
-    if(!localModel_->getG2Matrix()){
-	getG2Matrix = true;
-    }
-
-    if((getA2Matrix) || (getG2Matrix)){
-	getLowerMatrices(false, getA2Matrix, getG2Matrix);
+      localModel_->setCoeffMatrices();
     }
 
     //extracting optimal first-level solution of the relaxation problem and
@@ -1165,18 +1169,22 @@ MibSCutGenerator::getAlphaIC(double** extRay, double* uselessIneqs,
     double gap = (targetGap < etol) ? 0.0 : targetGap;
     double templObj(0.0); // YX: track SL optimal obj val
 
-    if(localModel_->getA2Matrix() == NULL){
-	getA2Matrix = true;
+  //   if(localModel_->getA2Matrix() == NULL){
+	// getA2Matrix = true;
+  //   }
+
+  //   if(localModel_->getG2Matrix() == NULL){
+	// getG2Matrix = true;
+  //   }
+
+  //   if((getA2Matrix) || (getG2Matrix)){
+	// getLowerMatrices(false, getA2Matrix, getG2Matrix);
+  //   }
+
+    if(!localModel_->getA2Matrix()){
+      localModel_->setCoeffMatrices();
     }
 
-    if(localModel_->getG2Matrix() == NULL){
-	getG2Matrix = true;
-    }
-
-    if((getA2Matrix) || (getG2Matrix)){
-	getLowerMatrices(false, getA2Matrix, getG2Matrix);
-    }
-    
     CoinPackedMatrix *matrixA2 = localModel_->getA2Matrix();
     CoinPackedMatrix *matrixG2 = localModel_->getG2Matrix();
 
@@ -1368,16 +1376,20 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
 
     origMatrix.reverseOrdering();
     
+  //   if(!localModel_->getLowerConstCoefMatrix()){
+	// getA2G2Matrix = true;
+  //   }
+
+  //   if(!localModel_->getG2Matrix()){
+	// getG2Matrix = true;
+  //   }
+
+  //   if((getA2G2Matrix) || (getG2Matrix)){
+	// getLowerMatrices(getA2G2Matrix, false, getG2Matrix);
+  //   }
+
     if(!localModel_->getLowerConstCoefMatrix()){
-	getA2G2Matrix = true;
-    }
-
-    if(!localModel_->getG2Matrix()){
-	getG2Matrix = true;
-    }
-
-    if((getA2G2Matrix) || (getG2Matrix)){
-	getLowerMatrices(getA2G2Matrix, false, getG2Matrix);
+      localModel_->setCoeffMatrices();
     }
 
     CoinPackedMatrix *matrixA2G2 = localModel_->getLowerConstCoefMatrix();
@@ -6580,6 +6592,7 @@ MibSCutGenerator::getBindingConsBasis()
 }
 
 //#############################################################################
+/**
 void
 MibSCutGenerator::getLowerMatrices(bool getLowerConstCoefMatrix,
 				   bool getA2Matrix, bool getG2Matrix)
@@ -6677,4 +6690,4 @@ MibSCutGenerator::getLowerMatrices(bool getLowerConstCoefMatrix,
 	localModel_->setG2Matrix(matrixG2);
     }
 
-}
+}**/

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -686,7 +686,7 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
 				mult = -1;
 				break;
 			    case 'E':
-				std::couta
+				std::cout
 				    << "MibS cannot currently handle equality constraints." << std::endl;
 				abort();
 				break;
@@ -828,7 +828,6 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
     double timeLimit(localModel_->AlpsPar()->entry(AlpsParams::timeLimit));
     double remainingTime(0.0);
 
-    // bool getA2Matrix(false), getG2Matrix(false);
     OsiSolverInterface * oSolver = localModel_->solver();
     double infinity(oSolver->getInfinity());
     int i, j;
@@ -890,18 +889,6 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
     CoinZeroN(newObjCoeff, newNumCols);
     int *integerVars = new int[newNumCols];
     CoinZeroN(integerVars, newNumCols);
-
-  //   if(!localModel_->getA2Matrix()){
-	// getA2Matrix = true;
-  //   }
-
-  //   if(!localModel_->getG2Matrix()){
-	// getG2Matrix = true;
-  //   }
-
-  //   if((getA2Matrix) || (getG2Matrix)){
-	// getLowerMatrices(false, getA2Matrix, getG2Matrix);
-  //   }
 
     if(!localModel_->getA2Matrix()){
       localModel_->setCoeffMatrices();
@@ -1156,23 +1143,10 @@ MibSCutGenerator::getAlphaIC(double** extRay, double* uselessIneqs,
     char *rowSense = localModel_->getOrigRowSense();
     double *lObjCoeffs(localModel_->getLowerObjCoeffs());
     double objSense(localModel_->getLowerObjSense());
-    // bool getA2Matrix(false), getG2Matrix(false);
 
     double targetGap(localModel_->MibSPar_->entry(MibSParams::slTargetGap));
     double gap = (targetGap < etol) ? 0.0 : targetGap;
     double templObj(0.0); // YX: track SL optimal obj val
-
-  //   if(localModel_->getA2Matrix() == NULL){
-	// getA2Matrix = true;
-  //   }
-
-  //   if(localModel_->getG2Matrix() == NULL){
-	// getG2Matrix = true;
-  //   }
-
-  //   if((getA2Matrix) || (getG2Matrix)){
-	// getLowerMatrices(false, getA2Matrix, getG2Matrix);
-  //   }
 
     if(!localModel_->getA2Matrix()){
       localModel_->setCoeffMatrices();
@@ -1325,9 +1299,6 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
     int whichCutsLL(localModel_->MibSPar_->entry
 		    (MibSParams::whichCutsLL));
     double targetGap(localModel_->MibSPar_->entry(MibSParams::slTargetGap));
-    double etol(localModel_->etol_);
-    double gap = (targetGap < etol) ? 0.0 : targetGap; // YX: added SL gap 
-    double templObj(0.0); // YX: for nonzero gap, track d^2y^*
 
     double timeLimit(localModel_->AlpsPar()->entry(AlpsParams::timeLimit));
     double remainingTime(0.0);
@@ -1335,10 +1306,12 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
     
     OsiSolverInterface *oSolver = localModel_->solver();
     double infinity(oSolver->getInfinity());
-    // bool getA2G2Matrix(false), getG2Matrix(false);
+    double etol(localModel_->getTolerance());
+
     int i, j;
     int rowIndex(0), colIndex(0), numElements(0), pos(0), cntInt(0);
     double rhs(0.0), value(0.0);
+    double templObj(0.0); // YX: for nonzero gap, track d^2y^*
     int numCols(localModel_->getNumCols());
     int lCols(localModel_->getLowerDim());
     int lRows(localModel_->getLowerRowNum());
@@ -1354,6 +1327,7 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
     double *origColLb(localModel_->getOrigColLb());
     double *origColUb(localModel_->getOrigColUb());
     char *origRowSense(localModel_->getOrigRowSense());
+    double gap = (targetGap < etol) ? 0.0 : targetGap; // YX: added SL gap 
     CoinPackedMatrix origMatrix = *localModel_->getOrigConstCoefMatrix();
 
     CoinShallowPackedVector origRow;
@@ -1365,18 +1339,6 @@ MibSCutGenerator::findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lo
 
     origMatrix.reverseOrdering();
     
-  //   if(!localModel_->getLowerConstCoefMatrix()){
-	// getA2G2Matrix = true;
-  //   }
-
-  //   if(!localModel_->getG2Matrix()){
-	// getG2Matrix = true;
-  //   }
-
-  //   if((getA2G2Matrix) || (getG2Matrix)){
-	// getLowerMatrices(getA2G2Matrix, false, getG2Matrix);
-  //   }
-
     if(!localModel_->getLowerConstCoefMatrix()){
       localModel_->setCoeffMatrices();
     }

--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -85,8 +85,8 @@ class MibSCutGenerator : public BlisConGenerator {
     int intersectionCuts(BcpsConstraintPool &conPool,
 			 double *optLowerSolution, MibSIntersectionCutType ICType);
     /** Helper function for IC*/
-    bool findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol, const double *sol,
-			   bool &isTimeLimReached);
+    bool findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol, double *optLowerSol, 
+			  const double *sol, bool &isTimeLimReached); // YX: add y^* for nonzero gap case
 
     /** Helper function for IC*/
     bool getAlphaIC(double** extRay, double *uselessIneqs, double* lowerSolution, int numStruct,
@@ -97,7 +97,7 @@ class MibSCutGenerator : public BlisConGenerator {
 
     /** Helper function for watermelon IC **/
     bool findLowerLevelSolWatermelonIC(double *uselessIneqs, double *lowerLevelSol,
-				       double* lpSol, bool &isTimeLimReached);
+				double *optLowerSol, double* lpSol, bool &isTimeLimReached); // YX: add y^* for nonzero gap case
 
     /** Helper function for watermelon IC*/
     bool getAlphaWatermelonIC(double** extRay, double *uselessIneqs, double* lowerSolution,

--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -186,7 +186,7 @@ class MibSCutGenerator : public BlisConGenerator {
    double * findDeepestLandPCut1();//stable (but maybe wrong)
 
    /** Store the matrices A2, G2 and lower-level coeffs (all constraints are 'L') **/
-   void getLowerMatrices(bool getLowerConstCoefMatrix, bool getA2Matrix, bool getG2Matrix);
+  //  void getLowerMatrices(bool getLowerConstCoefMatrix, bool getA2Matrix, bool getG2Matrix);
    
  private:
 

--- a/src/MibSHelp.hpp
+++ b/src/MibSHelp.hpp
@@ -21,8 +21,10 @@
 struct LINKING_SOLUTION{
     int tag;
     double lowerObjValue;
+    double pesRFValue; // YX: pessimistic case
     double UBObjValue;
     std::vector<double> lowerSolution;
+    std::vector<double> pesSolution; // YX: pessimistic case
     std::vector<double> UBSolution;
 };
 

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -3745,5 +3745,15 @@ MibSModel::instanceStructure()
           std::cout << "Linking solution pool will not be used." << std::endl;
 	}
     }
+    
+    //YX: Setting "slTargetGap" parameter
+
+    if (printProblemInfo == true){
+       if(MibSPar_->entry(MibSParams::slTargetGap) > -1){
+          std::cout << "Second (lower) level optimality gap is set to ";
+          std::cout << MibSPar_->entry(MibSParams::slTargetGap) <<"%."<< std::endl;
+       }
+    }
+
     std::cout << std::endl;
 }

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -3746,7 +3746,7 @@ MibSModel::instanceStructure()
 	}
     }
     
-    //YX: Setting "slTargetGap" parameter
+    //YX: Printing "slTargetGap" parameter; setting it as a model property?
 
     if (printProblemInfo == true){
        if(MibSPar_->entry(MibSParams::slTargetGap) > -1){

--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -105,6 +105,9 @@ private:
     /** Time for solving (VF) **/
     double timerVF_;
 
+    /** Time for solving (PES) **/
+    double timerPES_; // YX: pessimistic case;
+
     /** Time for solving (UB) **/
     double timerUB_;
 
@@ -156,7 +159,7 @@ private:
     /** the right (positive) slope of the lower-level value function **/
     double rightSlope_;
 
-    int countIteration_;
+    int countIteration_; // YX: HOW IS IT USED???
   
     /** Indices of UL variables **/
     int * upperColInd_;
@@ -218,10 +221,17 @@ private:
     /** Original matrix of constraints coefficients **/
     CoinPackedMatrix *origConstCoefMatrix_;
     
+    // YX: used in pessimistic feasibility check
     //we only fill next three matrices if they are required.
     //For now, we only need them for generating IC and watermelon IC.
     /** matrix of lower-level coefficients(all constraints are 'L') **/
     CoinPackedMatrix *lowerConstCoefMatrix_;
+
+    /** matrix of upper-level vars in upper-level problem (with row sense 'L') **/
+    CoinPackedMatrix *A1Matrix_;
+
+    /** matrix of lower-level vars in upper-level problem (with row sense 'L') **/
+    CoinPackedMatrix *G1Matrix_;
 
     /** matrix of upper-level vars in lower-level problem(all constraints are 'L') **/
     CoinPackedMatrix *A2Matrix_;
@@ -403,6 +413,12 @@ public:
     /** Set pointer to the matrix of LL coefficients(all constraints are 'L') **/
     void setLowerConstCoefMatrix(CoinPackedMatrix *ptr) {lowerConstCoefMatrix_ = ptr;}
 
+    /** YX: Set pointer to the matrix of UL vars in UL problem (with row sense 'L') **/
+    void setA1Matrix(CoinPackedMatrix *ptr) {A1Matrix_ = ptr;}
+    
+    /** YX: Set pointer to the matrix of LL vars in UL problem (with row sense 'L') **/
+    void setG1Matrix(CoinPackedMatrix *ptr) {G1Matrix_ = ptr;}
+    
     /** Set pointer to the matrix of UL vars in LL problem(all constraints are 'L') **/
     void setA2Matrix(CoinPackedMatrix *ptr) {A2Matrix_ = ptr;}
 
@@ -496,6 +512,12 @@ public:
 
     /** Get pointer to the matrix of LL coefficients(all constraints are 'L') **/
     CoinPackedMatrix * getLowerConstCoefMatrix() const {return lowerConstCoefMatrix_;}
+
+    /** YX: Get pointer to the matrix of UL vars in UL problem (with row sense 'L') **/
+    CoinPackedMatrix * getA1Matrix() const {return A1Matrix_;}
+
+    /** YX: Get pointer to the matrix of LL vars in UL problem (with row sense 'L') **/
+    CoinPackedMatrix * getG1Matrix() const {return G1Matrix_;}
 
     /** Get pointer to the matrix of UL vars in LL problem(all constraints are 'L') **/
     CoinPackedMatrix * getA2Matrix() const {return A2Matrix_;}
@@ -604,6 +626,10 @@ public:
   
     /** The method that decodes the model from an encoded object. */
     virtual void decodeToSelf(AlpsEncoded&);
+
+    /** YX: Separate and set A1, G1, A2, G2 matrices (with row sense 'L') **/
+    // YX: this was moved from MibSCutGenerator
+    void setCoeffMatrices();
 
     /** Determine the list of first-stage variables participate in second-stage constraints */
     void setRequiredFixedList();

--- a/src/MibSParams.cpp
+++ b/src/MibSParams.cpp
@@ -244,6 +244,8 @@ MibSParams::createKeywordList() {
    keys_.push_back(make_pair(std::string("MibS_boundCutTimeLim"),
 			     AlpsParameter(AlpsDoublePar, boundCutTimeLim)));
 
+   keys_.push_back(make_pair(std::string("MibS_slTargetGap"),
+			     AlpsParameter(AlpsDoublePar, slTargetGap)));     //YX: param for setting SL gap
 }
 
 //#############################################################################
@@ -386,6 +388,8 @@ MibSParams::setDefaultEntries() {
    //-------------------------------------------------------------
 
    setEntry(boundCutTimeLim, 3600);
+
+   setEntry(slTargetGap, -1); //YX: SL gap default set to -1
    
    //-------------------------------------------------------------
    // String Parameters

--- a/src/MibSParams.cpp
+++ b/src/MibSParams.cpp
@@ -66,6 +66,8 @@ MibSParams::createKeywordList() {
    keys_.push_back(make_pair(std::string("MibS_useNewPureIntCut"),
 			     AlpsParameter(AlpsBoolPar, useNewPureIntCut)));
 
+   keys_.push_back(make_pair(std::string("MibS_findPesSol"),
+			     AlpsParameter(AlpsBoolPar, findPesSol))); // YX: pessimistic case
    //--------------------------------------------------------
    // BoolArrayPar
    //--------------------------------------------------------
@@ -280,6 +282,8 @@ MibSParams::setDefaultEntries() {
    setEntry(allowRemoveCut, false);
 
    setEntry(useNewPureIntCut, false);
+
+   setEntry(findPesSol, false);   
 
    //-------------------------------------------------------------
    // Int Parameters.

--- a/src/MibSParams.hpp
+++ b/src/MibSParams.hpp
@@ -39,6 +39,8 @@ class MibSParams : public AlpsParameterSet {
      printProblemInfo,
      allowRemoveCut,
      useNewPureIntCut,
+     // YX: pessimistic case
+     findPesSol,
      endOfBoolParams
   };
   

--- a/src/MibSParams.hpp
+++ b/src/MibSParams.hpp
@@ -99,6 +99,7 @@ class MibSParams : public AlpsParameterSet {
   /** Double parameters. */
   enum dblParams{
       boundCutTimeLim,
+      slTargetGap, //YX: lower/second level optimality gap
       endOfDblParams
   };
 


### PR DESCRIPTION
The main changes in this draft:

- add gaps to related functions in UB problems setup and cut generations;
- add pessimistic related parameters and variables; add containers and tags to the linking solution pool; (these changes introduced check failure on call stack...)
- in MibSBilevel, change the feasibility checking procedures and add related problem setup functions;
- in MibSModel, add a function to store coefficient matrices A1, A2, G1, and G1 since they are used in pessimistic problem setup functions; 
- in MibSCutGenerator, remove getLowerMatrices() as it is replaced by the function above; related lines that appeared in finding solutions for the (watermelon) intersection cuts are also removed; 

A segmentation fault was introduced after adding the pessimistic parameters. Still trying to figure out where it was caused...

Will have more updates after running tests.