### PR TITLE
Add function to write aux file

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -913,7 +913,7 @@ MibSModel::readProblemData()
    //    Empty input: use the MPS file name and write AUX only
    //    Nonempty input: use the input name and write MPS + AUX files
    if(instName.compare("PARAM_NOTSET") != 0){
-      if(instName.compare("0") == 0){
+      if(instName.compare("-") == 0){
          instName.clear(); // YX: param found; reset name
       }
       if(!instName.empty()){
@@ -941,10 +941,9 @@ MibSModel::readProblemData()
                   "MibSModel");
       }
 
-   delete mps;
-   throw CoinError("Exit after mps/aux files are successfully written",
-                  "writeInstance",
-                  "MibSModel");
+      delete mps;
+      printf("Exit after mps/aux files are successfully written\n");
+      exit(0);
    }
    
    delete mps;

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -499,13 +499,15 @@ std::string cmtStr)
       fileName = instPath.substr(length + 1);
    }
    length = fileName.length();
-   if(fileName.back() == 's')
-   {  
+   if((length > 3) && (fileName.substr(length - 3) == "mps")){  
       // assume upperfile in .mps format
       line = fileName.erase(length - 4, 4);
-   }else{ 
+   }else if((length > 2) && (fileName.substr(length - 2) == "lp")){ 
       // assume upperfile in .lp format
       line = fileName.erase(length - 3, 3);
+   }else{
+      // assume input has no format indicator
+      line = fileName;
    }
    line.append(".aux");
 
@@ -914,8 +916,13 @@ MibSModel::readProblemData()
       if(instName.find("PARAM_NOTSET") + 1 > 0){
          instName.clear(); // YX: param found; reset name
       }
-      if(!instName.empty()){ 
-         rc = mps->writeMps(instName.c_str()); // YX: filename truncated @NAME
+      if(!instName.empty()){
+         // YX: write MPS using CoinIO function; filename truncated @NAME 
+         j = instName.length();
+         if((j <= 3) || (instName.substr(j - 3).compare("mps") != 0)){
+            instName.append(".mps"); 
+         }
+         rc = mps->writeMps(instName.c_str());
          if(rc){
             delete mps;
             throw CoinError("Unable to write instance",

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -504,10 +504,14 @@ std::string cmtStr)
    line.append("\n" + std::to_string(lowerDim_) + "\n"); 
    line.append("@NUMCONSTRS") ;
    line.append("\n" + std::to_string(lowerRowNum_) + "\n");   
-   memset(outputVal, 0, sizeof outputVal);
-   CoinConvertDouble(0, 0, lowerObjSense_, outputVal);
+   // memset(outputVal, 0, sizeof outputVal);
+   // CoinConvertDouble(0, 0, lowerObjSense_, outputVal);
    line.append("@OBJSENSE");
-   line.append("\n" + std::string(outputVal) + "\n");
+   if(lowerObjSense_ < 0){
+      line.append("\nMAX\n");
+   }else{
+      line.append("\nMIN\n");
+   }
    output->puts(line.c_str());
 
    // YX: write vars with objcoeff; then constraints;

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -913,7 +913,7 @@ MibSModel::readProblemData()
    //    Empty input: use the MPS file name and write AUX only
    //    Nonempty input: use the input name and write MPS + AUX files
    if(instName.compare("PARAM_NOTSET") != 0){
-      if(instName.find("PARAM_NOTSET") + 1 > 0){
+      if(instName.compare("0") == 0){
          instName.clear(); // YX: param found; reset name
       }
       if(!instName.empty()){

--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -543,6 +543,9 @@ public:
     /** Read auxiliary data file **/
     void readAuxiliaryData(int numCols, int numRows);
 
+    /** Write auxiliary data file **/
+    int writeAuxiliaryData(std::string filename);
+    
     /** Set auxiliary data directly when using MibS as a library **/
     void loadAuxiliaryData(int lowerColNum, int lowerRowNum,
 			   const int *lowerColInd,

--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -544,7 +544,8 @@ public:
     void readAuxiliaryData(int numCols, int numRows);
 
     /** Write auxiliary data file **/
-    int writeAuxiliaryData(std::string filename);
+    int writeAuxiliaryData(std::string filename, bool wName = false, 
+        std::string instPath = "", std::string cmtStr = "");
     
     /** Set auxiliary data directly when using MibS as a library **/
     void loadAuxiliaryData(int lowerColNum, int lowerRowNum,

--- a/src/MibSParams.cpp
+++ b/src/MibSParams.cpp
@@ -237,6 +237,9 @@ MibSParams::createKeywordList() {
    keys_.push_back(make_pair(std::string("MibS_inputFormat"),
 			     AlpsParameter(AlpsStringPar, inputFormat)));
 
+   keys_.push_back(make_pair(std::string("MibS_writeInstanceName"),
+			     AlpsParameter(AlpsStringPar, writeInstanceName)));
+
    //--------------------------------------------------------
    // Double Parameters.
    //--------------------------------------------------------
@@ -396,6 +399,8 @@ MibSParams::setDefaultEntries() {
    setEntry(feasCheckSolver, "SYMPHONY");
 
    setEntry(inputFormat, "indexBased");
+
+   setEntry(writeInstanceName, "");
 }
 
 //#############################################################################

--- a/src/MibSParams.cpp
+++ b/src/MibSParams.cpp
@@ -400,7 +400,7 @@ MibSParams::setDefaultEntries() {
 
    setEntry(inputFormat, "indexBased");
 
-   setEntry(writeInstanceName, "");
+   setEntry(writeInstanceName, "PARAM_NOTSET");
 }
 
 //#############################################################################

--- a/src/MibSParams.hpp
+++ b/src/MibSParams.hpp
@@ -108,6 +108,7 @@ class MibSParams : public AlpsParameterSet {
       auxiliaryInfoFile,
       feasCheckSolver,
       inputFormat,
+      writeInstanceName,
       endOfStrParams
   };
 


### PR DESCRIPTION
Added a function to write LL/SL/second stage problem into an auxiliary file; number style follows standard .mps format;

Will add/change 
- a MibS parameter for the writing option;
- the path/name of the file as a parameter;
- readAuxiliaryData() offer options to read LL/SL variables by name instead of indices?