### PR TITLE
Add write and read functions for name based auxiliary files

### DIFF
--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -601,6 +601,10 @@ public:
 			   int numCols, int numRows, double infinity,
 			   const char *rowSense);
 
+    /** Write auxiliary data file **/
+    int writeAuxiliaryData(std::string filename, bool wName = false, 
+        std::string instPath = "", std::string cmtStr = "");
+    
     /** Set auxiliary data directly when using MibS as a library **/
     void loadAuxiliaryData(int lowerColNum, int lowerRowNum,
 			   const int *lowerColInd,

--- a/src/MibSParams.cpp
+++ b/src/MibSParams.cpp
@@ -316,6 +316,9 @@ MibSParams::createKeywordList() {
    //So the parameter "isSMPSFormat" should be set to true.
    keys_.push_back(make_pair(std::string("MibS_stochasticityType"),
 			     AlpsParameter(AlpsStringPar, stochasticityType)));
+              
+   keys_.push_back(make_pair(std::string("MibS_writeInstanceName"),
+			     AlpsParameter(AlpsStringPar, writeInstanceName)));
 
    //--------------------------------------------------------
    // Double Parameters.
@@ -522,6 +525,8 @@ MibSParams::setDefaultEntries() {
    setEntry(inputFormat, "indexBased");
 
    setEntry(stochasticityType, "deterministic");
+
+   setEntry(writeInstanceName, "PARAM_NOTSET");
 }
 
 //#############################################################################

--- a/src/MibSParams.hpp
+++ b/src/MibSParams.hpp
@@ -131,6 +131,7 @@ class MIBSLIB_EXPORT MibSParams : public AlpsParameterSet {
       feasCheckSolver,
       inputFormat,
       stochasticityType,
+      writeInstanceName,
       endOfStrParams
   };
 


### PR DESCRIPTION
Commits are copied from stable/1.2. 

Note: the master branch contains reading functions for stochastic case related files, and they are still using the index-based format.