### PR TITLE
Add code to handle equality constraints

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -516,6 +516,9 @@ std::string cmtStr)
    }else if((length > 2) && (fileName.substr(length - 2) == "lp")){ 
       // assume upperfile in .lp format
       line = fileName.erase(length - 3, 3);
+   }else if(fileName.substr(length - 2) == "gz"){
+      // assume upperfile in .gz format
+      line = fileName.erase(length - 7, 7);
    }else{
       // assume input has no format indicator
       line = fileName;

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -510,15 +510,19 @@ std::string cmtStr)
       fileName = instPath.substr(length + 1);
    }
    length = fileName.length();
-   if((length > 3) && (fileName.substr(length - 3) == "mps")){  
+
+   // YX: assume .gz, .mps, or .lp formats
+   if(fileName.substr(length - 3) == ".gz"){
+      fileName.erase(length - 3, 3);
+      length -= 3;
+   }
+   
+   if((length > 3) && (fileName.substr(length - 4) == ".mps")){  
       // assume upperfile in .mps format
       line = fileName.erase(length - 4, 4);
-   }else if((length > 2) && (fileName.substr(length - 2) == "lp")){ 
+   }else if((length > 2) && (fileName.substr(length - 3) == ".lp")){ 
       // assume upperfile in .lp format
       line = fileName.erase(length - 3, 3);
-   }else if(fileName.substr(length - 2) == "gz"){
-      // assume upperfile in .gz format
-      line = fileName.erase(length - 7, 7);
    }else{
       // assume input has no format indicator
       line = fileName;

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -276,7 +276,10 @@ MibSModel::readAuxiliaryData(int numCols, int numRows)
       std::string mpsFile(getUpperFile());
       int length = mpsFile.length();
       char *tmpArr = new char[length + 1];
-      fileName = mpsFile.erase(length - 3, 3);
+      if (mpsFile.substr(mpsFile.find_last_of(".")+1) == "gz"){
+         mpsFile = mpsFile.substr(0, mpsFile.find_last_of("."));
+      }
+      fileName = mpsFile.substr(0, mpsFile.find_last_of(".")+1);
       fileName.append("aux");
       if (fileCoinReadable(fileName)){
 	  fileName.copy(tmpArr, length);
@@ -287,7 +290,7 @@ MibSModel::readAuxiliaryData(int numCols, int numRows)
           std::cout << "MibS used " <<  fileName << " automatically.";
           std::cout << std::endl;
       }else{
-          fileName = mpsFile.erase(length - 3, 3);
+          fileName = mpsFile.substr(0, mpsFile.find("."));
           fileName.append("txt");
 	  if (fileCoinReadable(fileName)){
 	      fileName.copy(tmpArr, length);

--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -90,6 +90,9 @@ private:
     /** Number of LL constraints **/
     int lowerRowNum_;
 
+    /** YX: Number of LL constraints in problem input file **/
+    int inputLowerRowNum_;
+    
     /** Number of structural constraints **/
     int structRowNum_;
 
@@ -172,6 +175,9 @@ private:
 
     /** Indices of LL rows **/
     int * lowerRowInd_;
+
+    /** YX: Indices of LL rows in problem input file **/
+    int * inputLowerRowInd_;
 
     /** Indices of structural (non-vub) rows **/
     int * structRowInd_;


### PR DESCRIPTION
The equality constraints are handled at the beginning of `MibSModel::loadProblemData()`, after reading the `MPS` and `AUX` files, before further data loading. Then, `MibSModel` only recognizes the problem after parsing equality constraints. This is different from the original plan described in Slack as I was trying to place all the iterations in one block. 

Added variables: `inputLowerRowInd_`,  `inputLowerRowNum_` to track the original data from input files; they are necessary if writeAuxData is called.

Change in the output: printed information from `mps` functions will show the original row numbers, and those from `MibS` analyzing data will reflect the split row numbers.