### PR TITLE
Read range constraints (continue): remove redundant condition check and fix bugs

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -1022,9 +1022,7 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
    std::vector<double> rowUBVec(rowUB, rowUB+inputNumRows);
    
    for(i = 0; i < inputNumRows; i++){
-      if((rowSense[i] == 'E') || 
-         ((rowLB[i] > -1*infinity) && (rowUB[i] < infinity))){
-         
+      if(((rowLB[i] > -1*infinity) && (rowUB[i] < infinity))){
          for(j = 0; j < inputLowerRowNum_; j++){
             if(inputLowerRowInd_[j] == i){
                lowerRowIndVec.push_back(numRows);
@@ -2211,13 +2209,13 @@ MibSModel::findIndex(int index, int size, int * indices)
   bool found(false);
 
   for(i = 0; i < size; i++){
-    if(indices[i] == index)
+    if(indices[i] == index){
       found = true;
+      break;
+    }
   }
 
   return found;
-
-
 }
 
 //#############################################################################
@@ -3642,7 +3640,7 @@ MibSModel::instanceStructure()
            case 'R':
              std::cout << "MibS cannot currently handle range constraints.";
              std::cout << std::endl;
-             abort();
+             abort(); // YX: handled in loadProblemData()
              break;
           }
           if ((fabs(rhs - floor(rhs)) > etol_) &&

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -1022,7 +1022,7 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
    std::vector<double> rowUBVec(rowUB, rowUB+inputNumRows);
    
    for(i = 0; i < inputNumRows; i++){
-      if(((rowLB[i] > -1*infinity) && (rowUB[i] < infinity))){
+      if((rowSense[i] == 'E') || (rowSense[i] == 'R')){
          for(j = 0; j < inputLowerRowNum_; j++){
             if(inputLowerRowInd_[j] == i){
                lowerRowIndVec.push_back(numRows);
@@ -3633,12 +3633,12 @@ MibSModel::instanceStructure()
              rhs = conLB_[i];
              break;
            case 'E':
-             std::cout << "MibS cannot currently handle equality constraints.";
+             std::cout << "Something went wrong in equality constraints conversion.";
              std::cout << std::endl; 
              abort(); // YX: handled in loadProblemData()
              break;
            case 'R':
-             std::cout << "MibS cannot currently handle range constraints.";
+             std::cout << "Something went wrong in range constraints conversion.";
              std::cout << std::endl;
              abort(); // YX: handled in loadProblemData()
              break;


### PR DESCRIPTION
Fixed some minor bugs. No (substantive) changes to read/write functions.

1. removed a redundant condition check for equality/range constraints (though I think C++ is using a short circuit logic so it may not be that redundant?);
2. added `break` to `findIndex()` so it terminates once the target is found;
3. added comments for reference.