### PR TITLE
avoid printing the same information to std::out twice

### DIFF
--- a/src/MibSSolution.cpp
+++ b/src/MibSSolution.cpp
@@ -166,9 +166,11 @@ MibSSolution::print(std::ostream& os) const
       }
    }
 
-   std::cout << "Number of problems (VF) solved = " << localModel_->counterVF_ << std::endl;
-   std::cout << "Number of problems (UB) solved = " << localModel_->counterUB_ << std::endl;
-   std::cout << "Time for solving problem (VF) = " << localModel_->timerVF_ << std::endl;
-   std::cout << "Time for solving problem (UB) = " << localModel_->timerUB_ << std::endl;
+   if(&os == &std::cout){
+      std::cout << "Number of problems (VF) solved = " << localModel_->counterVF_ << std::endl;
+      std::cout << "Number of problems (UB) solved = " << localModel_->counterUB_ << std::endl;
+      std::cout << "Time for solving problem (VF) = " << localModel_->timerVF_ << std::endl;
+      std::cout << "Time for solving problem (UB) = " << localModel_->timerUB_ << std::endl;
+   }
 }
 


### PR DESCRIPTION
Following up on #115  : fix the problem that some information was displayed twice when printing solutions to a file.