### PR TITLE
Add error handler if invalid lowerObjCoeffs; fix a bug in writeAuxData

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -424,6 +424,9 @@ MibSModel::readAuxiliaryData(int numCols, int numRows)
 	 for(i = 0; i < lowerColNum; i++){
 	     data_stream >> cValue;
 	     data_stream >> dValue;
+         if(data_stream.peek() == EOF){
+            goto TERM_ENDREADAUXDATA;
+         }
 	     for(p = 0; p < numCols; ++p){
 		 if(columnName_[p] == cValue){
 		     pos = p;
@@ -434,8 +437,10 @@ MibSModel::readAuxiliaryData(int numCols, int numRows)
 		 std::cout << cValue << " does not belong to the list of variables." << std::endl;
 	     }
 	     else{
-		 lowerObjCoeffs_[i] = dValue;
 		 lowerColInd_[i] = pos;
+         // YX: counter idx changed to match N at TERM
+         lowerObjCoeffs_[k] = dValue;
+         k++;
 	     }
 	     pos = -1;
 	 }
@@ -477,11 +482,21 @@ MibSModel::readAuxiliaryData(int numCols, int numRows)
      }
   }
   
+TERM_ENDREADAUXDATA:
+
   data_stream.close();
   
   std::cout << "LL Data File: " << getLowerFile() << "\n";
   std::cout << "Number of LL Variables:   " 
 	    << getLowerDim() << "\n\n";
+
+   // YX: throw error if invalid lower/2nd objCoeffs input 
+   if((!getLowerObjCoeffs()) || (k != lowerColNum)){
+      throw CoinError("Missing second-stage (lower level) objective coefficient(s)",
+                     "readAuxiliaryData",
+                     "MibSModel");
+   }
+
 }
 
 //#############################################################################
@@ -545,6 +560,7 @@ std::string cmtStr)
    line.append(ss.str());
    line.append("@NUMCONSTRS") ;
    ss.clear();
+   ss.str("");
    ss << std::endl << lowerRowNum_ << std::endl;
    line.append(ss.str());
    line.append("@OBJSENSE");


### PR DESCRIPTION
The added lines will check whether lower level (2nd stage) objective coefficients are given as expected in the input auxiliary file. If an empty/blank input is detected, `throw CoinError` to end the program.

Also fixed a bug in writeAuxiliaryData, where the `stringstream` content needs to be cleared before the next write.