### PR TITLE
skip the generation of Benders binary cut if the bigM problem is unbounded

### DIFF
--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -30,6 +30,7 @@ class MibSCutGenerator : public BlisConGenerator {
    int maximalCutCount_;
    int numCalledBoundCut_;
    bool isBigMIncObjSet_;
+   bool isBigMIncObjErr_;
    double bigMIncObj_;
    OsiSolverInterface * ImprovingDirectionICSolver_;
    std::vector<int> leafNodeCutTmpHist_; 

--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -30,7 +30,6 @@ class MibSCutGenerator : public BlisConGenerator {
    int maximalCutCount_;
    int numCalledBoundCut_;
    bool isBigMIncObjSet_;
-   bool isBigMIncObjErr_;
    double bigMIncObj_;
    OsiSolverInterface * ImprovingDirectionICSolver_;
    std::vector<int> leafNodeCutTmpHist_; 
@@ -162,7 +161,8 @@ class MibSCutGenerator : public BlisConGenerator {
    /** Add disjunctive cuts for binary upper-level variables (maximal sol) **/
    int bendersBinaryCutMaximal(BcpsConstraintPool &conPool);
 
-   double findBigMBendersBinaryCut();
+   /** Solve the big M problem for Benders binary cut **/
+   bool findBigMBendersBinaryCut(double &bigM);
 
    /** Add disjunctive cuts for binary upper-level variables (current sol)**/
    int weakBendersBinaryCutCurrent(BcpsConstraintPool &conPool);

--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -29,8 +29,8 @@ class MibSCutGenerator : public BlisConGenerator {
    int auxCount_;
    int maximalCutCount_;
    int numCalledBoundCut_;
-   bool isBigMIncObjSet_;
-   double bigMIncObj_;
+   bool isBigMBendBinSet_;
+   double bigMBendBin_;
    OsiSolverInterface * ImprovingDirectionICSolver_;
    std::vector<int> leafNodeCutTmpHist_; 
     


### PR DESCRIPTION
Caused by unbounded \llv\ variables.

- If the bigM problem is determined unbounded or does not have an optimal solution, set the value of bigM to `-inf`.
- Add a boolean variable `isBigMIncObjErr_` to track this case, and turn off Benders binary cut once the error is detected.

Will run more tests.