### PR TITLE
Fix the node pruning logic when the time limit is reached

### DIFF
--- a/src/MibSBilevel.cpp
+++ b/src/MibSBilevel.cpp
@@ -334,7 +334,8 @@ MibSBilevel::checkBilevelFeasibility(bool isRoot)
 
 	remainingTime = timeLimit - model_->broker_->subTreeTimer().getTime();
 	if(remainingTime <= etol){
-	    shouldPrune_ = true;
+	    // YX: replace shouldPrune_ by timeout
+	    model_->setTimeLimitReached();
 	    storeSol = MibSNoSol;
 	    goto TERM_CHECKBILEVELFEAS;
 	}
@@ -429,7 +430,8 @@ MibSBilevel::checkBilevelFeasibility(bool isRoot)
 	if((feasCheckSolver == "SYMPHONY") && (sym_is_time_limit_reached
 					       (dynamic_cast<OsiSymSolverInterface *>
 						(lSolver)->getSymphonyEnvironment()))){
-	    shouldPrune_ = true;
+	    // YX: replace shouldPrune_ by timeout
+	    model_->setTimeLimitReached();
 	    storeSol = MibSNoSol;
 	    goto TERM_CHECKBILEVELFEAS;
 	}
@@ -555,7 +557,8 @@ MibSBilevel::checkBilevelFeasibility(bool isRoot)
 		remainingTime = timeLimit - model_->broker_->subTreeTimer().getTime();
 
 		if(remainingTime <= etol){
-		    shouldPrune_ = true;
+		    // YX: replace shouldPrune_ by timeout
+		    model_->setTimeLimitReached();
 		    goto TERM_CHECKBILEVELFEAS;
 		}
 		
@@ -618,7 +621,8 @@ MibSBilevel::checkBilevelFeasibility(bool isRoot)
 		if((feasCheckSolver == "SYMPHONY") && (sym_is_time_limit_reached
 						       (dynamic_cast<OsiSymSolverInterface *>
 							(UBSolver)->getSymphonyEnvironment()))){
-		    shouldPrune_ = true;
+		    // YX: replace shouldPrune_ by timeout
+		    model_->setTimeLimitReached();
 		    goto TERM_CHECKBILEVELFEAS;
 		}
 

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -577,18 +577,11 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
 		    double *lowerLevelSol = new double[lCols];
 		    CoinZeroN(uselessIneqs, lRows);
 		    CoinZeroN(lowerLevelSol, lCols);
-		    isTimeLimReached = false;
-		    if (!findLowerLevelSol(uselessIneqs, lowerLevelSol, sol, isTimeLimReached)){
+		    if (!findLowerLevelSol(uselessIneqs, lowerLevelSol, sol)){
                        delete [] uselessIneqs;
                        delete [] lowerLevelSol;
                        goto TERM_INTERSECTIONCUT;
                     }
-            // YX: not used since it has been handled above
-            // if(isTimeLimReached == true){
-            //     delete [] uselessIneqs;
-            //     delete [] lowerLevelSol;
-            //     goto TERM_INTERSECTIONCUT;
-            // }
 		    intersectionFound = getAlphaIC(extRay, uselessIneqs, lowerLevelSol,
 						   numStruct, numNonBasic, sol, alpha);
 
@@ -615,19 +608,11 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
 	        double *lowerLevelSol = new double[lCols];
 	        CoinZeroN(uselessIneqs, lRows);
 	        CoinZeroN(lowerLevelSol, lCols);
-		isTimeLimReached = false;
-	        if (!findLowerLevelSolImprovingDirectionIC(uselessIneqs, lowerLevelSol, lpSol,
-                                                   isTimeLimReached)){
+	        if (!findLowerLevelSolImprovingDirectionIC(uselessIneqs, lowerLevelSol, lpSol)){
 		    delete [] uselessIneqs;
 		    delete [] lowerLevelSol;
 		    goto TERM_INTERSECTIONCUT;
                 }                   
-	        // YX: not used since it has been handled above
-	        // if(isTimeLimReached == true){
-	        //     delete [] uselessIneqs;
-	        //     delete [] lowerLevelSol;
-	        //     goto TERM_INTERSECTIONCUT;
-	        // }
 		intersectionFound = getAlphaImprovingDirectionIC(extRay, uselessIneqs, lowerLevelSol,
 							 numStruct, numNonBasic, lpSol, alpha);
 	        delete [] uselessIneqs;
@@ -822,7 +807,7 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
 //#############################################################################
 bool
 MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
-				    const double *sol, bool &isTimeLimReached)
+				    const double *sol)
 {
     
     std::string feasCheckSolver(localModel_->MibSPar_->entry
@@ -1025,7 +1010,6 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
     remainingTime = timeLimit - localModel_->broker_->subTreeTimer().getTime();
 
     if(remainingTime <= localModel_->etol_){
-        isTimeLimReached = true;
         localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
     }
     else{
@@ -1081,7 +1065,6 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
         if((feasCheckSolver == "SYMPHONY") && (sym_is_time_limit_reached
 					       (dynamic_cast<OsiSymSolverInterface *>
 						(nSolver)->getSymphonyEnvironment()))){
-	    isTimeLimReached = true;
 	    localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
 	}
 	else if(nSolver->isProvenOptimal()){
@@ -1286,7 +1269,7 @@ MibSCutGenerator::solveModelIC(double *uselessIneqs, double *ray, double *rhs,
 //#############################################################################
 bool
 MibSCutGenerator::findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, double *lowerLevelSol,
-						double* lpSol, bool &isTimeLimReached)
+						double* lpSol)
 {
     std::string feasCheckSolver(localModel_->MibSPar_->entry
 				(MibSParams::feasCheckSolver));
@@ -1541,7 +1524,6 @@ MibSCutGenerator::findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, do
 					   (dynamic_cast<OsiSymSolverInterface *>
 					    (nSolver)->getSymphonyEnvironment())))
        || (timeLimit - localModel_->broker_->subTreeTimer().getTime() < 3)){
-        isTimeLimReached = true;
         localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
     }
     else if(nSolver->isProvenOptimal()){

--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -583,11 +583,12 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
                        delete [] lowerLevelSol;
                        goto TERM_INTERSECTIONCUT;
                     }
-		    if(isTimeLimReached == true){
-			delete [] uselessIneqs;
-			delete [] lowerLevelSol;
-			goto TERM_INTERSECTIONCUT;
-		    }
+            // YX: not used since it has been handled above
+            // if(isTimeLimReached == true){
+            //     delete [] uselessIneqs;
+            //     delete [] lowerLevelSol;
+            //     goto TERM_INTERSECTIONCUT;
+            // }
 		    intersectionFound = getAlphaIC(extRay, uselessIneqs, lowerLevelSol,
 						   numStruct, numNonBasic, sol, alpha);
 
@@ -621,11 +622,12 @@ MibSCutGenerator::intersectionCuts(BcpsConstraintPool &conPool,
 		    delete [] lowerLevelSol;
 		    goto TERM_INTERSECTIONCUT;
                 }                   
-		if(isTimeLimReached == true){
-		    delete [] uselessIneqs;
-		    delete [] lowerLevelSol;
-		    goto TERM_INTERSECTIONCUT;
-		}
+	        // YX: not used since it has been handled above
+	        // if(isTimeLimReached == true){
+	        //     delete [] uselessIneqs;
+	        //     delete [] lowerLevelSol;
+	        //     goto TERM_INTERSECTIONCUT;
+	        // }
 		intersectionFound = getAlphaImprovingDirectionIC(extRay, uselessIneqs, lowerLevelSol,
 							 numStruct, numNonBasic, lpSol, alpha);
 	        delete [] uselessIneqs;
@@ -1023,8 +1025,8 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
     remainingTime = timeLimit - localModel_->broker_->subTreeTimer().getTime();
 
     if(remainingTime <= localModel_->etol_){
-	isTimeLimReached = true;
-	localModel_->bS_->shouldPrune_ = true;
+        isTimeLimReached = true;
+        localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
     }
     else{
 	remainingTime = CoinMax(remainingTime, 0.00);
@@ -1080,7 +1082,7 @@ MibSCutGenerator::findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol,
 					       (dynamic_cast<OsiSymSolverInterface *>
 						(nSolver)->getSymphonyEnvironment()))){
 	    isTimeLimReached = true;
-	    localModel_->bS_->shouldPrune_ = true;
+	    localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
 	}
 	else if(nSolver->isProvenOptimal()){
 	    const double *optSol = nSolver->getColSolution();
@@ -1539,8 +1541,8 @@ MibSCutGenerator::findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, do
 					   (dynamic_cast<OsiSymSolverInterface *>
 					    (nSolver)->getSymphonyEnvironment())))
        || (timeLimit - localModel_->broker_->subTreeTimer().getTime() < 3)){
-	isTimeLimReached = true;
-	localModel_->bS_->shouldPrune_ = true;
+        isTimeLimReached = true;
+        localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
     }
     else if(nSolver->isProvenOptimal()){
 	const double *optSol = nSolver->getColSolution();
@@ -1735,8 +1737,8 @@ MibSCutGenerator::storeBestSolHypercubeIC(const double* lpSol, double optLowerOb
     remainingTime = timeLimit - localModel_->broker_->subTreeTimer().getTime();
 
     if(remainingTime <= localModel_->etol_){
-	isTimeLimReached = true;
-	bS->shouldPrune_ = true;
+        isTimeLimReached = true;
+        localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
     }
     else{
 	remainingTime = CoinMax(remainingTime, 0.00);
@@ -1800,8 +1802,8 @@ MibSCutGenerator::storeBestSolHypercubeIC(const double* lpSol, double optLowerOb
         if((feasCheckSolver == "SYMPHONY") && (sym_is_time_limit_reached
 					       (dynamic_cast<OsiSymSolverInterface *>
 						(UBSolver)->getSymphonyEnvironment()))){
-	    isTimeLimReached = true;
-	    bS->shouldPrune_ = true;
+            isTimeLimReached = true;
+            localModel_->setTimeLimitReached(); // YX: replace shouldPrune_ by timeout
 	}
 	else if(UBSolver->isProvenOptimal()){
 	    MibSSolution *mibsSol = new MibSSolution(numCols,

--- a/src/MibSCutGenerator.hpp
+++ b/src/MibSCutGenerator.hpp
@@ -85,8 +85,7 @@ class MibSCutGenerator : public BlisConGenerator {
     int intersectionCuts(BcpsConstraintPool &conPool,
 			 double *optLowerSolution, MibSIntersectionCutType ICType);
     /** Helper function for IC*/
-    bool findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol, const double *sol,
-			   bool &isTimeLimReached);
+    bool findLowerLevelSol(double *uselessIneqs, double *lowerLevelSol, const double *sol);
 
     /** Helper function for IC*/
     bool getAlphaIC(double** extRay, double *uselessIneqs, double* lowerSolution, int numStruct,
@@ -97,7 +96,7 @@ class MibSCutGenerator : public BlisConGenerator {
 
     /** Helper function for ImprovingDirectionIC **/
     bool findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, double *lowerLevelSol,
-				       double* lpSol, bool &isTimeLimReached);
+				       double* lpSol);
 
     /** Helper function for ImprovingDirectionIC*/
     bool getAlphaImprovingDirectionIC(double** extRay, double *uselessIneqs, double* lowerSolution,

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -157,6 +157,7 @@ MibSModel::initialize()
   positiveA2_ = true;
   positiveG1_ = true;
   positiveG2_ = true;
+  timeLimitReached_ = false;
   colSignsG2_ = NULL;
   colSignsA2_ = NULL;
   upperColInd_ = NULL;

--- a/src/MibSModel.hpp
+++ b/src/MibSModel.hpp
@@ -156,6 +156,9 @@ private:
     /** Determines if matrix G2 is positive or not **/
     bool positiveG2_;
 
+    /** YX: Determines if time limit is reached or exceeded **/
+    bool timeLimitReached_;
+
     /** The signs of columns of matrix G2 (for Benders interdiction cut) **/
     int * colSignsG2_;
    
@@ -375,6 +378,12 @@ public:
 
     /** Set whether the problem is interdiction **/
     inline void setInterdictionProblem(bool b = true) {isInterdict_ = b;}
+
+    /** Query whether the time limit is reached **/
+    inline bool isTimeLimitReached() {return timeLimitReached_;}
+
+    /** Set whether the time limit is reached **/
+    inline void setTimeLimitReached(bool b = true) {timeLimitReached_ = b;}
 
     /** Set UL column indices **/
     void setUpperColInd(int *ptr) {upperColInd_ = ptr;} 

--- a/src/MibSTreeNode.cpp
+++ b/src/MibSTreeNode.cpp
@@ -398,6 +398,10 @@ MibSTreeNode::process(bool isRoot, bool rampUp)
 	  if((!ipSol) && (bS->shouldPrune_)){
 	      setStatus(AlpsNodeStatusFathomed);
 	      goto TERM_PROCESS;
+	  }else if((!ipSol) && (mibsModel->isTimeLimitReached())){
+	      // YX: mark node as partially processed
+	      setStatus(AlpsNodeStatusEvaluated);
+	      goto TERM_PROCESS;
 	  }
 	      
 	  if (ipSol) {

--- a/src/MibSTreeNode.cpp
+++ b/src/MibSTreeNode.cpp
@@ -771,8 +771,11 @@ MibSTreeNode::process(bool isRoot, bool rampUp)
 		    setStatus(AlpsNodeStatusFathomed);
 		    quality_ = -ALPS_OBJ_MAX;
 		    goto TERM_PROCESS;
-		}
-		    
+		}else if(mibsModel->isTimeLimitReached()){
+		    // YX: mark node as partially processed
+		    setStatus(AlpsNodeStatusEvaluated);
+		    goto TERM_PROCESS;
+		}   
             
 		if (lpStatus != BlisLpStatusOptimal) {
 		    setStatus(AlpsNodeStatusFathomed);


### PR DESCRIPTION
MibS feasibility check would label current node as should be pruned if timeout happens during solving the lower-level/second-stage problem. The terminating log will output the best lower bound as if the latest node is not yet processed.

Changes:
- Added a boolean variable in `MibSModel` as a flag once the preset time limit is reached during the feasibility check in `MibSBilevel`.
- In `MibSCutGenerator`, add the same exit flag when timeout during generating various intersection cuts.
- In `MibSTreeNode`, mark the most recent node exploration as "partially processed", so the termination process will keep the node knowledge instead of removing it. 
