### PR TITLE
Fix a bug when setting up the improving direction intersection cut

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -3845,7 +3845,8 @@ MibSModel::adjustParameters()
     paramValue = MibSPar_->entry(MibSParams::useImprovingDirectionIC);
     
     if (paramValue == PARAM_NOTSET){
-       if (isPureInteger_ == false || isLowerCoeffInt_ == false || isInterdict_ == true){
+       if (isPureInteger_ == false || isLowerCoeffInt_ == false || 
+          isLowerObjInt_ == false || isInterdict_ == true){
           MibSPar()->setEntry(MibSParams::useImprovingDirectionIC, PARAM_OFF);
        }else{
           MibSPar()->setEntry(MibSParams::useImprovingDirectionIC, PARAM_ON);


### PR DESCRIPTION
When IDIC parameter is not set, add a condition in the check to make sure that the cut cannot be turned on if some of the lower objective coefficients are not integers. 