### PR TITLE
skip IDIC if the generation problem returns infeasible solution - follow up

### DIFF
--- a/src/MibSCutGenerator.cpp
+++ b/src/MibSCutGenerator.cpp
@@ -1273,6 +1273,7 @@ MibSCutGenerator::findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, do
     int whichCutsLL(localModel_->MibSPar_->entry
 		    (MibSParams::whichCutsLL));
     double timeLimit(localModel_->AlpsPar()->entry(AlpsParams::timeLimit));
+    double etol(localModel_->etol_);
     double remainingTime(0.0);
     bool foundSolution = false;
     
@@ -1527,7 +1528,7 @@ MibSCutGenerator::findLowerLevelSolImprovingDirectionIC(double *uselessIneqs, do
 	CoinDisjointCopyN(optSol, lCols, lowerLevelSol);
       // YX: numerical issue; skip if the lowerLevelSol found is all zero
       for(i = 0; i < lCols; i++){
-        if(fabs(lowerLevelSol[i]) > 0){
+        if(fabs(lowerLevelSol[i]) > etol){
           solErr = false;
           break;
         }


### PR DESCRIPTION
This PR fixed a bug in [a previous change](https://github.com/coin-or/MibS/pull/131#issue-2019981938) #131  that skipped the generation of an improving direction intersection cut when the generation problem returned an all-zero solution.

The new line determines the all-zero solution using the defined tolerance instead of zero.

