### PR TITLE
Check input matrix orientation when loading problem data

### DIFF
--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -1083,7 +1083,8 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
    int problemType(MibSPar_->entry(MibSParams::bilevelProblemType));
 
    int i(0), j(0), k(0), start(0), end(0), beg(0);
-
+   
+   bool matType = matrix.isColOrdered(); // YX: check input matrix orientation
    int inputNumRows = matrix.getNumRows(); // YX: to diff from #eqConstrs
    int numCols = matrix.getNumCols();
 
@@ -1097,6 +1098,13 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
    CoinPackedMatrix rowMatrix;
    CoinPackedMatrix *newMatrix = NULL;
    CoinPackedMatrix *matrix1 = NULL; // YX: w/ appended equality constrs
+   
+   // YX: need col mat to start; cp to matrix1 if row-ordered
+   if(!matType){
+      matrix1 = new CoinPackedMatrix();
+      matrix1->copyOf(matrix);
+      matrix1->reverseOrdering();
+   }
 
    // --- prepare for equality constraints (if any) ---
    
@@ -1155,12 +1163,17 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
 
    // YX: add rows to the problem matrix and link pointers to vectors 
    if(numRows > inputNumRows){
-      matrix1 = new CoinPackedMatrix();
-      matrix1->copyOf(matrix);
+      if(!matrix1){
+         matrix1 = new CoinPackedMatrix();
+         matrix1->copyOf(matrix);
+      }
       matrix1->reverseOrdering();
 
       rowMatrix = matrix;
-      rowMatrix.reverseOrdering();
+      // YX: switch if matrix was col ordered
+      if(matType){
+         rowMatrix.reverseOrdering();
+      }
       const double * matElements = rowMatrix.getElements();
       const int * matIndices = rowMatrix.getIndices();
       const int * matStarts = rowMatrix.getVectorStarts();

--- a/src/MibSModel.cpp
+++ b/src/MibSModel.cpp
@@ -1099,11 +1099,10 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
    CoinPackedMatrix *newMatrix = NULL;
    CoinPackedMatrix *matrix1 = NULL; // YX: w/ appended equality constrs
    
-   // YX: need col mat to start; cp to matrix1 if row-ordered
+   // YX: note that MibS defaults to using a column matrix.
    if(!matType){
-      matrix1 = new CoinPackedMatrix();
-      matrix1->copyOf(matrix);
-      matrix1->reverseOrdering();
+      throw CoinError("Expect a column-oriented matrix. Try matrix.reverseOrdering() before loading the matrix.", 
+         "loadProblemData", "MibSModel");
    }
 
    // --- prepare for equality constraints (if any) ---
@@ -1163,17 +1162,12 @@ MibSModel::loadProblemData(const CoinPackedMatrix& matrix,
 
    // YX: add rows to the problem matrix and link pointers to vectors 
    if(numRows > inputNumRows){
-      if(!matrix1){
-         matrix1 = new CoinPackedMatrix();
-         matrix1->copyOf(matrix);
-      }
+      matrix1 = new CoinPackedMatrix();
+      matrix1->copyOf(matrix);
       matrix1->reverseOrdering();
 
       rowMatrix = matrix;
-      // YX: switch if matrix was col ordered
-      if(matType){
-         rowMatrix.reverseOrdering();
-      }
+      rowMatrix.reverseOrdering();
       const double * matElements = rowMatrix.getElements();
       const int * matIndices = rowMatrix.getIndices();
       const int * matStarts = rowMatrix.getVectorStarts();


### PR DESCRIPTION
To fix the bug in #134: since `loadProblemData()` expects a column-oriented data matrix, we consider adding a check to the beginning of the function and creating a reversed copy if a row-oriented matrix is detected.